### PR TITLE
Narrow search by product group

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Simple wrapper for ruby-aaws
 ## Usage
     require 'amazon/aws/simple'
     aws = Amazon::AWS::Simple::Search.new(key_id, secret_key_id, affiliate_tag, country_code, encoding, cacahe_dir)
-    items = aws.retrieve_by_keyword('Ruby')
+    items = aws.retrieve_by_keyword('Books', 'Ruby')
     items.first.title
       # => 7.50 Carat Ruby & White Sapphire Heart Pendant in Sterling Silver with 18" Chain,
 

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ Simple wrapper for ruby-aaws
     aws = Amazon::AWS::Simple::Search.new(key_id, secret_key_id, affiliate_tag, country_code, encoding, cacahe_dir)
     items = aws.retrieve_by_keyword('Books', 'Ruby')
     items.first.title
-      # => 7.50 Carat Ruby & White Sapphire Heart Pendant in Sterling Silver with 18" Chain,
+      # => The Ruby Programming Language
 

--- a/examples/test.rb
+++ b/examples/test.rb
@@ -8,5 +8,5 @@ if $0 == __FILE__
 
   Amazon::AWS::Simple::Search.logger = Logger.new(STDERR)
   aws = Amazon::AWS::Simple::Search.new(key_id, secret_key_id, "hoge-22", "us", "utf-8", cache_dir)
-  puts aws.retrieve_by_keyword('ruby').map(&:title)
+  puts aws.retrieve_by_keyword('All', 'ruby').map(&:title)
 end

--- a/lib/amazon/aws/simple.rb
+++ b/lib/amazon/aws/simple.rb
@@ -60,8 +60,8 @@ module Amazon::AWS::Simple
       }.flatten
     end
 
-    def search_by_keyword(keyword)
-      _search_by_keyword(keyword)
+    def search_by_keyword(product_group, keyword)
+      _search_by_keyword(product_group, keyword)
     end
 
     ## 更につかいやすくしたやつ
@@ -71,8 +71,8 @@ module Amazon::AWS::Simple
       }
     end
 
-    def retrieve_by_keyword(keyword)
-      search_by_keyword(keyword).map{ |item|
+    def retrieve_by_keyword(product_group, keyword)
+      search_by_keyword(product_group, keyword).map{ |item|
         Data.new.load_from_aws_item(item)
       }
     end
@@ -104,8 +104,8 @@ module Amazon::AWS::Simple
       end
     end
 
-    def _search_by_keyword(keyword)
-      item_search("All", {'Keywords' => keyword})
+    def _search_by_keyword(product_group, keyword)
+      item_search(product_group, {'Keywords' => keyword})
     end
   end
 


### PR DESCRIPTION
Great work on this gem. It hasn't been updated in a while but still seems to be working a-okay!

I had to customise my local version a little for my own needs and thought it might also be a good addition for the gem itself.

The retrieve_by_keyword method now takes another argument which is the category/product group to search into e.g. all, books, etc.
